### PR TITLE
[Fix] #50 API 버그 수정 및 naver 검색 '무슨동 무슨구' 형식으로만 반환하도록 수정

### DIFF
--- a/common/src/main/java/entity/Pin.java
+++ b/common/src/main/java/entity/Pin.java
@@ -11,11 +11,11 @@ public class Pin {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "house_id")
     private House house;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "user_id")
     private User user;
 }

--- a/producer/src/main/java/server/producer/domain/repository/PinRepository.java
+++ b/producer/src/main/java/server/producer/domain/repository/PinRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface PinRepository extends JpaRepository<Pin, Long> {
     Optional<Pin> findByUserIdAndHouseId(Long userId, Long houseId);
-    void deleteByUserIdAndHouseId(Long userId, Long houseId);
+//    void deleteByUserIdAndHouseId(Long userId, Long houseId);
 }

--- a/producer/src/main/java/server/producer/domain/repository/RecentlyViewedHouseRepository.java
+++ b/producer/src/main/java/server/producer/domain/repository/RecentlyViewedHouseRepository.java
@@ -1,0 +1,12 @@
+package server.producer.domain.repository;
+
+import entity.RecentlyViewedHouse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecentlyViewedHouseRepository extends JpaRepository<RecentlyViewedHouse, Long> {
+	Optional<RecentlyViewedHouse> findByUserIdAndHouseId(Long userId, Long houseId);
+}

--- a/producer/src/main/java/server/producer/domain/repository/RecentlyViewedHouseRepository.java
+++ b/producer/src/main/java/server/producer/domain/repository/RecentlyViewedHouseRepository.java
@@ -4,9 +4,12 @@ import entity.RecentlyViewedHouse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RecentlyViewedHouseRepository extends JpaRepository<RecentlyViewedHouse, Long> {
 	Optional<RecentlyViewedHouse> findByUserIdAndHouseId(Long userId, Long houseId);
+
+	List<RecentlyViewedHouse> findByUserIdOrderByViewedAtDesc(Long userId);
 }

--- a/producer/src/main/java/server/producer/domain/service/MapService.java
+++ b/producer/src/main/java/server/producer/domain/service/MapService.java
@@ -21,15 +21,9 @@ public class MapService {
 			throw new IllegalArgumentException();
 		}
 		String[] parts = location.split(" ");
-		String gu = null;
-		String dong = null;
-		for (String part : parts) {
-			if (part.endsWith("구")) {
-				gu = part;
-			} else if (part.endsWith("동")) {
-				dong = part;
-			}
-		}
+		String gu = parts[1];
+		String dong = parts[2];
+
 		FilterRequestDto updated;
 		if (gu != null && dong != null) {
 			location =  gu + " " + dong;

--- a/producer/src/main/java/server/producer/domain/service/UserService.java
+++ b/producer/src/main/java/server/producer/domain/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import server.producer.domain.dto.response.HomeInfoResponseDto;
 import server.producer.domain.dto.response.MyPageResponseDto;
 import server.producer.domain.repository.HouseRepository;
+import server.producer.domain.repository.RecentlyViewedHouseRepository;
 import server.producer.domain.repository.UserRepository;
 import entity.House;
 import entity.RecentlyViewedHouse;
@@ -21,6 +22,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final HouseRepository houseRepository;
+	private final RecentlyViewedHouseRepository recentlyViewedHouseRepository;
 
 	public HomeInfoResponseDto getUserInfoAndRecentlyViewedHouse(Long userId) {
 		// 사용자 정보 조회
@@ -30,9 +32,10 @@ public class UserService {
 		final String location = user.getLocation().split(" ")[user.getLocation().split(" ").length-1];
 		final List<HomeInfoResponseDto.RecentlyViewedHouseDto> recentlyViewedHouseDtos = new ArrayList<>();
 
-		List<House> houses = houseRepository.findRecentlyViewedHousesByUserId(user.getId());
+		List<RecentlyViewedHouse> houses = recentlyViewedHouseRepository.findByUserIdOrderByViewedAtDesc(user.getId());
 
-		for (House house : houses) {
+		for (RecentlyViewedHouse rvh : houses) {
+			House house = rvh.getHouse();
 			List<Room> rooms = house.getRooms();
 			final boolean isPinned = house.getPins().stream()
 					.anyMatch(pin -> pin.getUser().getId().equals(userId));

--- a/producer/src/test/java/domain/service/UserServiceTest.java
+++ b/producer/src/test/java/domain/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import server.producer.domain.dto.response.HomeInfoResponseDto;
 import server.producer.domain.repository.HouseRepository;
+import server.producer.domain.repository.RecentlyViewedHouseRepository;
 import server.producer.domain.repository.UserRepository;
 import server.producer.domain.service.UserService;
 
@@ -27,6 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class UserServiceTest {
     @Mock
     private UserRepository userRepository;
+
+	@Mock
+	private RecentlyViewedHouseRepository recentlyViewedHouseRepository;
 
 	@Mock
 	private HouseRepository houseRepository;
@@ -66,8 +70,10 @@ public class UserServiceTest {
 
 		when(userRepository.findUserWithRecentlyViewedHouses(anyLong()))
 				.thenReturn(Optional.of(user));
-		when(houseRepository.findRecentlyViewedHousesByUserId(user.getId()))
-				.thenReturn(user.getRecentlyViewedHouses().stream().map(RecentlyViewedHouse::getHouse).toList());
+		when(recentlyViewedHouseRepository.findByUserIdOrderByViewedAtDesc(user.getId()))
+				.thenReturn(user.getRecentlyViewedHouses().stream().toList());
+
+
 		//when
 		HomeInfoResponseDto result = userService.getUserInfoAndRecentlyViewedHouse(userId);
 		HomeInfoResponseDto.RecentlyViewedHouseDto resultHouse = result.recentlyViewedHouses().get(0);


### PR DESCRIPTION
## 이슈번호
> #50 

## 어떤 기능인가요?
> PATCH /v1/houses/{houseId}/pins 버그 수정
> /v1/locations?q= -> 변경X
> /v1/maps/search -> 무슨구 무슨동 로직 -> 인덱스 기반으로 수정 남대문1로가(이것도 동이다)
> v1/users/mypage -> 최근 본 방 기록

## 작업 상세 내용
- togglePin 서비스 수정
-  searchProperties 구와 동 수정
-  '동'을 이용해서 파싱하는 부분 전부 인덱스 방식으로 수정
-  getHouseDetails viewed At 추가